### PR TITLE
Screenshot source - adding a video source from screenshot vis MSS - and added CPU only option.

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -22,16 +22,15 @@ from detic.config import add_detic_config
 
 from detic.predictor import VisualizationDemo
 
-# Fake a video capture object
+# Fake a video capture object OpenCV style - half width, half height of first screen using MSS
 class ScreenGrab:
     def __init__(self):
         self.sct = mss.mss()
-        self.monitor = {"top": 40, "left": 0, "width": 800, "height": 640}
-        print(self.sct.monitors)
+        m0 = self.sct.monitors[0]
+        self.monitor = {'top': 0, 'left': 0, 'width': m0['width'] / 2, 'height': m0['height'] / 2}
 
     def read(self):
         img =  np.array(self.sct.grab(self.monitor))
-        img = cv2.resize(img, dsize=(800, 640), interpolation=cv2.INTER_CUBIC)
         nf = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
         return (True, nf)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 opencv-python
+mss
 timm
 dataclasses
 ftfy


### PR DESCRIPTION
This PR adds a few things to the demo of Detic. First it enables running on a CPU-only machine (like my MacBook). It adds a possibility to add a screenshot video source for anyone that might not have a webcam but still would like to have the ability to run something "live". This is also useful if you, like me, want to put your teams/zoom windows in that corner and run Detic on you, colleagues, in meeting and share that window ;-).

New option: --cpu
Changed option: --webcam <source>
Where the <source> argument takes either an int of the index of the video-source or "screen" for doing a screen capture of the upper left corner of the screen (half-width, half-height).