### PR TITLE
Fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Integrated into [Huggingface Spaces 🤗](https://huggingface.co/spaces) using [
 Run our demo using Colab (no GPU needed): [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1QtTW9-ukX2HKZGvt0QvVGqjuqEykoZKI)
 
 We use the default detectron2 [demo interface](https://github.com/facebookresearch/detectron2/blob/main/GETTING_STARTED.md). 
-For example, to run our [21K model](docs/MODEL_ZOO#cross-dataset-evaluation) on a [messy desk image](https://web.eecs.umich.edu/~fouhey/fun/desk/desk.jpg) (image credit [David Fouhey](https://web.eecs.umich.edu/~fouhey)) with the lvis vocabulary, run
+For example, to run our [21K model](docs/MODEL_ZOO.md#cross-dataset-evaluation) on a [messy desk image](https://web.eecs.umich.edu/~fouhey/fun/desk/desk.jpg) (image credit [David Fouhey](https://web.eecs.umich.edu/~fouhey)) with the lvis vocabulary, run
 
 ~~~
 mkdir models
@@ -98,7 +98,7 @@ Please first [prepare datasets](datasets/README.md), then check our   [MODEL ZOO
 
 ## License
 
-The majority of Detic is licensed under the [Apache 2.0 license](LICENSE), however portions of the project are available under separate license terms: SWIN-Transformer, CLIP, and TensorFlow Object Detection API are licensed under the MIT license; UniDet is licensed under the Apache 2.0 license; and the LVIS API is licensed under a custom license (https://github.com/lvis-dataset/lvis-api/blob/master/LICENSE)” If you later add other third party code, please keep this license info updated, and please let us know if that component is licensed under something other than CC-BY-NC, MIT, or CC0
+The majority of Detic is licensed under the [Apache 2.0 license](LICENSE), however portions of the project are available under separate license terms: SWIN-Transformer, CLIP, and TensorFlow Object Detection API are licensed under the MIT license; UniDet is licensed under the Apache 2.0 license; and the LVIS API is licensed under a [custom license](https://github.com/lvis-dataset/lvis-api/blob/master/LICENSE). If you later add other third party code, please keep this license info updated, and please let us know if that component is licensed under something other than CC-BY-NC, MIT, or CC0
 
 ## Ethical Considerations
 Detic's wide range of detection capabilities may introduce similar challenges to many other visual recognition and open-set recognition methods.

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -131,7 +131,7 @@ This creates `datasets/objects365/zhiyuan_objv2_train_fixname_fixmiss.json`.
 
 ### OpenImages
 
-We followed the instructions in [UniDet](https://github.com/xingyizhou/UniDet/blob/master/projects/UniDet/unidet_docs/DATASETS.md#openimages) to convert the metadata for OpenImages.
+We followed the instructions in [UniDet](https://github.com/xingyizhou/UniDet/blob/master/docs/DATASETS.md#openimages) to convert the metadata for OpenImages.
 
 The converted folder should look like
 

--- a/docs/MODEL_ZOO.md
+++ b/docs/MODEL_ZOO.md
@@ -67,7 +67,7 @@ please download the models and place them under `DETIC_ROOT/models/`, and follow
 |         Name          |Training time |  box mAP | box mAP_rare  | Download |
 |-----------------------|------------------|-----------|-----------------|----------|
 |[Box-Supervised_DeformDETR_R50_2x](../configs/BoxSup-DeformDETR_L_R50_4x.yaml)   |  31h | 31.7 |  21.4     |  [model](https://dl.fbaipublicfiles.com/detic/BoxSup-DeformDETR_L_R50_4x.pth) |
-|[Detic_DeformDETR_R50_2x](configs/Detic_DeformDETR_LI_R50_4x_ft4x.yaml) | 47h | 32.5  | 26.2  | [model](https://dl.fbaipublicfiles.com/detic/Detic_DeformDETR_LI_R50_4x_ft4x.pth) |
+|[Detic_DeformDETR_R50_2x](../configs/Detic_DeformDETR_LI_R50_4x_ft4x.yaml) | 47h | 32.5  | 26.2  | [model](https://dl.fbaipublicfiles.com/detic/Detic_DeformDETR_LI_R50_4x_ft4x.pth) |
 
 
 #### Note


### PR DESCRIPTION
Hi.
Fixed links:
- to _21K model_ and _LVIS API licence_ in `README.md`
- to _UniDet_ repository in `datasets/REAMDE.md`
- to _Detic_DeformDETR_R50_2x_ config in `docs/MODEL_ZOO.md`